### PR TITLE
Fix Bluetooth permission checker in StartView

### DIFF
--- a/app/src/main/java/fi/metropolia/movesense/util/PermissionUtil.kt
+++ b/app/src/main/java/fi/metropolia/movesense/util/PermissionUtil.kt
@@ -12,7 +12,6 @@ class PermissionUtil {
             context: Context,
             onCheckPermissions: (Array<String>) -> Unit
         ): Boolean {
-            var btChecked = false
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 if (ContextCompat.checkSelfPermission(
                         context,
@@ -29,32 +28,29 @@ class PermissionUtil {
                             Manifest.permission.BLUETOOTH_CONNECT
                         )
                     )
-                } else {
-                    btChecked = true
+                    return false
                 }
+                return true
             } else {
-                btChecked = true
-            }
-            var locChecked = false
-            if (ContextCompat.checkSelfPermission(
-                    context,
-                    Manifest.permission.ACCESS_COARSE_LOCATION
-                ) != PackageManager.PERMISSION_GRANTED &&
-                ContextCompat.checkSelfPermission(
-                    context,
-                    Manifest.permission.ACCESS_FINE_LOCATION
-                ) != PackageManager.PERMISSION_GRANTED
-            ) {
-                onCheckPermissions(
-                    arrayOf(
-                        Manifest.permission.ACCESS_COARSE_LOCATION,
+                if (ContextCompat.checkSelfPermission(
+                        context,
+                        Manifest.permission.ACCESS_COARSE_LOCATION
+                    ) != PackageManager.PERMISSION_GRANTED &&
+                    ContextCompat.checkSelfPermission(
+                        context,
                         Manifest.permission.ACCESS_FINE_LOCATION
+                    ) != PackageManager.PERMISSION_GRANTED
+                ) {
+                    onCheckPermissions(
+                        arrayOf(
+                            Manifest.permission.ACCESS_COARSE_LOCATION,
+                            Manifest.permission.ACCESS_FINE_LOCATION
+                        )
                     )
-                )
-            } else {
-                locChecked = true
+                    return false
+                }
+                return true
             }
-            return btChecked && locChecked
         }
     }
 }

--- a/app/src/main/java/fi/metropolia/movesense/view/start/StartView.kt
+++ b/app/src/main/java/fi/metropolia/movesense/view/start/StartView.kt
@@ -29,7 +29,7 @@ fun StartView(navController: NavController, startViewModel: StartViewModel = vie
     val isSearching = startViewModel.isSearching.observeAsState()
     val permissionsLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
-            it.values.all { value -> value }
+            permissionsGiven = it.values.all { value -> value }
         }
 
     Scaffold(
@@ -59,22 +59,15 @@ fun StartView(navController: NavController, startViewModel: StartViewModel = vie
                         isSearching = isSearching.value ?: false,
                         onStartScan = { startViewModel.startScan() }
                     )
-                } else {
-                    permissionsGiven =
-                        PermissionUtil.checkBluetoothPermissions(
-                            context,
-                            onCheckPermissions = { permissionsLauncher.launch(it) }
-                        )
                 }
             }
         }
     )
 
     LaunchedEffect(Unit) {
-        permissionsGiven =
-            PermissionUtil.checkBluetoothPermissions(
-                context,
-                onCheckPermissions = { permissionsLauncher.launch(it) }
-            )
+        permissionsGiven = PermissionUtil.checkBluetoothPermissions(
+            context,
+            onCheckPermissions = { permissionsLauncher.launch(it) }
+        )
     }
 }


### PR DESCRIPTION
When permissions are allowed at first launch, the scanning is now shown. Checking the permissions could be part of scanner component in future.